### PR TITLE
Adding log4j-detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of awesome links related to the [Log4Shell](https://security.snyk
 - [LizardLabs query tool](https://github.com/lizardlabs/Log-Parser-Lizard-Queries/blob/master/queries/log4shell/log4shell.search.MD5.sql) - Search for vulnerable jar files using MS Log Parser.
 - [Canary tokens](https://help.canary.tools/hc/en-gb/articles/4413465229201) - Use a canary token to test for vulnerable systems.
 - [Exploit Strings data](https://github.com/rapid7/data/tree/master/log4shell/heisenberg) - JNDI exploit strings seen in the wild by Rapid7.
+- [log4j-detector](https://github.com/mergebase/log4j-detector) - Detects vulnerable log4j versions on your file-system within any application.
 
 ## Twitter Discussions
 - [Log4Shell spreadsheet](https://twitter.com/GossiTheDog/status/1470056396968374273?s=20) - Spreadsheet for defenders listing vendors and products.


### PR DESCRIPTION
Detects vulnerable log4j versions on your file-system within any application. It is able to even find instances that are hidden several layers deep. Works on Linux, Windows, and Mac, and everywhere else Java runs, too!

Currently detects log4j-core versions 2.12.2 and 2.16.0 as SAFE, 2.15.0 as OKAY and all other versions as VULNERABLE (although it does report pre-2.0-beta9 as "POTENTIALLY_SAFE").

Can correctly detect log4j inside executable spring-boot jars/wars, dependencies blended into uber jars, shaded jars, and even exploded jar files just sitting uncompressed on the file-system (aka *.class).